### PR TITLE
doc: added README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Dagaz
+
+Dagaz is an universal engine to develop abstract board games with JavaScript/HTML. It provides graphical user interface, AI player, and a large collection of implements of board games and logical puzzles.
+
+## Demo
+
+[Here](https://glukkazan.github.io/) is a demo working on your web browser, which includes a variety of board games and logical puzzles.
+
+## Information
+
+For general idea of Dagaz, see articles below:
+
+- [Dagaz: Новое начало](https://habr.com/en/post/242547/) : Russian (original)
+- [Dagaz: A new Beginning](https://habr.com/ru/post/481868/) : English (translated)
+
+For detailed idea of Dagaz and its technology, see articles below (written in Russian):
+
+1. [Dagaz: Вновь об XSLT / Хабр](https://habr.com/ru/post/245849/)
+2. [Dagaz: Факториал — это просто! / Хабр](https://habr.com/ru/post/247263/)
+3. [Dagaz: Пинки здравому смыслу (часть 1) / Хабр](https://habr.com/ru/post/248639/)
+4. [Dagaz: Пинки здравому смыслу (часть 2) / Хабр](https://habr.com/ru/post/248821/)
+5. [Dagaz: Пинки здравому смыслу (часть 3) / Хабр](https://habr.com/ru/post/251401/)
+6. [Dagaz: Пинки здравому смыслу (часть 4) / Хабр](https://habr.com/ru/post/253397/)
+7. [Dagaz: Пинки здравому смыслу (часть 5) / Хабр](https://habr.com/ru/post/255621/)
+8. [Dagaz: Пинки здравому смыслу (часть 6) / Хабр](https://habr.com/ru/post/256701/)
+9. [Dagaz: Пинки здравому смыслу (часть 7) / Хабр](https://habr.com/ru/post/258437/)
+10. [Dagaz: Пинки здравому смыслу (часть 8) / Хабр](https://habr.com/ru/post/259611/)
+11. [Dagaz: На полпути / Хабр](https://habr.com/ru/post/270033/)
+12. [Dagaz: В дебрях нотаций / Хабр](https://habr.com/ru/post/309096/)
+13. [Dagaz: эволюция вместо революции / Хабр](https://habr.com/ru/post/320474/)
+14. [Dagaz: Архитектура / Хабр](https://habr.com/ru/post/322212/)
+15. [Dagaz: От простого к сложному / Хабр](https://habr.com/ru/post/323198/)
+16. [Dagaz: Репетиция / Хабр](https://habr.com/ru/post/327180/)
+17. [Dagaz: Забегая вперёд / Хабр](https://habr.com/ru/post/330320/)
+18. [Dagaz: Шажки / Хабр](https://habr.com/ru/post/335228/)
+19. [Dagaz: Быстрее Лучше Умнее… / Хабр](https://habr.com/ru/post/349516/)
+20. [Dagaz: Ищем таланты / Хабр](https://habr.com/ru/post/353116/)
+21. [Dagaz: Орда / Хабр](https://habr.com/ru/post/416595/)
+22. [Dagaz: Из тумана / Хабр](https://habr.com/ru/post/422427/)
+23. [Dagaz: Подробности / Хабр](https://habr.com/ru/post/429494/)
+24. [Dagaz: Ошибки / Хабр](https://habr.com/ru/post/440116/)
+25. [Dagaz: Эпизоды (часть 1) / Хабр](https://habr.com/ru/post/459456/)
+26. [Dagaz: Конец одиночества / Хабр](https://habr.com/ru/post/470065/)
+27. [Dagaz: Эпизоды (часть 2) / Хабр](https://habr.com/ru/post/472908/)
+28. [Dagaz: Сумма технологий / Хабр](https://habr.com/ru/post/486082/)
+29. [Dagaz: История с персистентностью / Хабр](https://habr.com/ru/post/491296/)
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE.txt file for details.


### PR DESCRIPTION
Resolves #2

## What

This commit adds a README file to the repository, which makes it easier for users to know the purpose and structure of Dagaz.

## Why

Dagaz is really a cool, useful, and wonderful project, but this repository has no descriptions or documents for its users/developers. IMHO, I think that the text files in ``/doc`` are not "descriptions" because they are too complicated and confusing for those who are not familiar with Dagaz to understand it - no matter how great a project is, if it doesn't have any descriptions people will rarely want to use or contribute to it. 

Of course, the README that I wrote doesn't have enough information yet;
It is just a first draft that we need to make better and more detailed.

It would be nice if the project has some user-friendly descriptions on the repository.

----

I translated my comments above into Russian with [Google](https://translate.google.com/);

Эта фиксация добавляет файл README в репозиторий, что упрощает пользователям понимание цели и структуры Dagaz.

Dagaz - действительно классный, полезный и замечательный проект, но в этом репозитории нет описаний или документов для его пользователей / разработчиков. По моему скромному мнению, я считаю, что текстовые файлы в / doc не являются «описаниями», потому что они слишком сложны и сбивают с толку тех, кто не знаком с Dagaz, чтобы понять его - независимо от того, насколько велик проект, если он не не иметь каких-либо описаний, которые люди редко захотят использовать или вносить в него.

Конечно, в README, который я написал, еще недостаточно информации;
Это всего лишь первый набросок, который нам нужно сделать лучше и детальнее.

Было бы неплохо, если бы у проекта в репозитории были удобные описания.